### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,8 @@
   <img align="center" alt="Arthur-PY" height="30" width="40" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" />
   <img align="center" alt="Arthur-HTML" height="30" width="40" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg" />
   <img align="center" alt="Arthur-CSS" height="30" width="40" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-original.svg" />
-  <img align="center" alt="Arthur-NVIM" height="30" width="40" src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/neovim/neovim-original.svg" />
-  <img align="center" alt="Arthur-INKSCAPE" height="30" width="40"src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/inkscape/inkscape-original.svg" />
-  <img align="center" alt="Arthur-GIMP" height="30" width="40" src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/gimp/gimp-original.svg" />
-  <img align="center" alt="Arthur-ARCH" height="30" width="40" src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/archlinux/archlinux-original.svg" />          
+  <img align="center" alt="Arthur-NVIM" height="30" width="40" src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/neovim/neovim-original.svg"/>
+  <img align="center" alt="Arthur-Linux" height="30" width="40" src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/linux/linux-original.svg" />                 
 </div>
   
   ##


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Replace specific Linux distribution icon (Arch Linux) with a generic Linux icon, and remove Inkscape and GIMP icons